### PR TITLE
Adding support to export coverage stats as CSV and to decolorize blocks again.

### DIFF
--- a/emerald.py
+++ b/emerald.py
@@ -20,6 +20,8 @@ from ghidra.app.decompiler import DecompInterface, DecompileOptions
 from ghidra.framework.plugintool.util import OptionsService
 from ghidra.util.task import TaskMonitor
 
+import csv
+
 service = state.getTool().getService(ColorizingService)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This commit provides two functionalities:
- CSV export of coverage stats
- Decolorization of any prior colorized blocks.

CSV coverage stats export:
Now the user is asked, whether they want to export stats as shown in the TableChooserDialog, once the colorization is completed. If the user wants to, they are asked to provide an export path.

Decolorization of any prior colorized blocks:
Upon dismissing the TableChooserDialog the user is asked whether they want to reset the decolorize the blocks again.
Due to a bug/problem which causes a TransactionException in case one tries to decolorize blocks which have been colorized before, it is needed to wrap any (de-)colorizatio into a transaction block using start() and end(True). Further information about this bug/Problem can be found here: https://github.com/NationalSecurityAgency/ghidra/pull/1845#issuecomment-644206484

In addition to the above mentioned things, also some minor refactoring is applied (mainly to increase PEP008 conformity