### PR TITLE
fixing block_data_lan value

### DIFF
--- a/emerald.py
+++ b/emerald.py
@@ -174,6 +174,7 @@ def parse_drcov_binary_blocks(block_data, filename, module_ids, module_base, mod
     remainder = block_data_len % 8
     if remainder != 0:
         block_data = block_data[:-remainder]
+        block_data_len -= remainder
     if debug:
         module_dict = {}
 


### PR DESCRIPTION
Adjusting block_data_lan according to the remainder value (https://github.com/reb311ion/emerald/blob/master/emerald.py#L174-L176). The figure below shows an example of the exception that might occur without that little adjustment

![emerald_fix](https://github.com/reb311ion/emerald/assets/32848129/78348c8f-2b96-46d7-b886-e9d67cb84ddf)
